### PR TITLE
Fix #7

### DIFF
--- a/Src/Public/Invoke-AsBuiltReport.VMware.ESXi.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.VMware.ESXi.ps1
@@ -225,43 +225,54 @@ function Invoke-AsBuiltReport.VMware.ESXi {
                             #endregion ESXi Host Boot Devices
 
                             #region ESXi Host PCI Devices
-                            Section -Style Heading3 'PCI Devices' {
+                            Try {
                                 $PciHardwareDevices = $esxcli.hardware.pci.list.Invoke() | Where-Object { $_.VMkernelName -match 'vmhba|vmnic|vmgfx' -and $_.ModuleName -ne 'None'} | Sort-Object -Property VMkernelName
-                                $VMHostPciDevices = foreach ($PciHardwareDevice in $PciHardwareDevices) {
-                                    [PSCustomObject]@{
-                                        'Device' = $PciHardwareDevice.VMkernelName
-                                        'PCI Address' = $PciHardwareDevice.Address
-                                        'Device Class' = $PciHardwareDevice.DeviceClassName
-                                        'Device Name' = $PciHardwareDevice.DeviceName
-                                        'Vendor Name' = $PciHardwareDevice.VendorName
-                                        'Slot Description' = $PciHardwareDevice.SlotDescription
+                            } Catch {
+                                Write-PScriboMessage -IsWarning "Unable to collect PCI Devices configuration from $($VMHost.ExtensionData.Name)"
+                            }
+                            if ($PciHardwareDevices) {
+                                Section -Style Heading3 'PCI Devices' {
+                                    $VMHostPciDevices = foreach ($PciHardwareDevice in $PciHardwareDevices) {
+                                        [PSCustomObject]@{
+                                            'Device' = $PciHardwareDevice.VMkernelName
+                                            'PCI Address' = $PciHardwareDevice.Address
+                                            'Device Class' = $PciHardwareDevice.DeviceClassName
+                                            'Device Name' = $PciHardwareDevice.DeviceName
+                                            'Vendor Name' = $PciHardwareDevice.VendorName
+                                            'Slot Description' = $PciHardwareDevice.SlotDescription
+                                        }
                                     }
+                                    $TableParams = @{
+                                        Name = "PCI Devices - $($VMHost.ExtensionData.Name)"
+                                        ColumnWidths = 12, 13, 15, 25, 20, 15
+                                    }
+                                    if ($Report.ShowTableCaptions) {
+                                        $TableParams['Caption'] = "- $($TableParams.Name)"
+                                    }
+                                    $VMHostPciDevices | Table @TableParams
                                 }
-                                $TableParams = @{
-                                    Name = "PCI Devices - $($VMHost.ExtensionData.Name)"
-                                    ColumnWidths = 12, 13, 15, 25, 20, 15
-                                }
-                                if ($Report.ShowTableCaptions) {
-                                    $TableParams['Caption'] = "- $($TableParams.Name)"
-                                }
-                                $VMHostPciDevices | Table @TableParams
                             }
                             #endregion ESXi Host PCI Devices
 
                             #region ESXi Host PCI Devices Drivers & Firmware
-                            Section -Style Heading3 'PCI Devices Drivers & Firmware' {
+                            Try {
                                 $VMHostPciDevicesDetails = Get-PciDeviceDetail -Server $ESXi -esxcli $esxcli | Sort-Object 'Device'
-                                $TableParams = @{
-                                    Name = "PCI Devices Drivers & Firmware - $($VMHost.ExtensionData.Name)"
-                                    ColumnWidths = 12, 20, 11, 19, 11, 11, 16
+                            } Catch {
+                                Write-PScriboMessage -IsWarning "Unable to collect PCI Devices Drivers & Firmware configuration from $($VMHost.ExtensionData.Name)"
+                            }
+                            if ($VMHostPciDevicesDetails) {
+                                Section -Style Heading3 'PCI Devices Drivers & Firmware' {
+                                    $TableParams = @{
+                                        Name = "PCI Devices Drivers & Firmware - $($VMHost.ExtensionData.Name)"
+                                        ColumnWidths = 12, 20, 11, 19, 11, 11, 16
+                                    }
+                                    if ($Report.ShowTableCaptions) {
+                                        $TableParams['Caption'] = "- $($TableParams.Name)"
+                                    }
+                                    $VMHostPciDevicesDetails | Table @TableParams
                                 }
-                                if ($Report.ShowTableCaptions) {
-                                    $TableParams['Caption'] = "- $($TableParams.Name)"
-                                }
-                                $VMHostPciDevicesDetails | Table @TableParams
                             }
                             #endregion ESXi Host PCI Devices Drivers & Firmware
-                            #>
                         }
                         #endregion ESXi Host Hardware Section
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added code to allow reporting to continue on PCI Devices and PCI Devices Drivers & Firmware tables that do not return data.

## Related Issue

- Fix #7 

## Motivation and Context

- Generating a VMware Esxi As Built Report with VMHost InfoLevel >=3 fails when collecting PCI Device information from VMware ESXi 8.0 hosts. During investigation it has been found that the following code does not return any results on an ESXi 8.0 host, but has worked previously on ESXi 7.0 U3 hosts.

## How Has This Been Tested?

- Esxi 7 & 8 host

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
